### PR TITLE
Currently enrolled CSC 413 function and student readonly version added

### DIFF
--- a/src/main/java/edu/sfsu/AdvisingServlet.java
+++ b/src/main/java/edu/sfsu/AdvisingServlet.java
@@ -134,6 +134,19 @@ public class AdvisingServlet extends HttpServlet {
         out.println(html);
     }
 
+    private void processLookupStudent(PrintWriter out, String id, boolean readonly) throws IOException {
+        Student student = campusDB.getStudent(id);
+        String html;
+        if (student != null) {
+            commentDB.getComments(student);
+            checkpointDB.getCheckpoints(student);
+            html = HtmlFormatter.generateHtml(student, readonly);
+        } else {
+            html = "<b>Student not found</b>";
+        }
+        out.println(html);
+    }
+
     private void processUpdateComment(String id, String course, String comment) {
         commentDB.updateComment(id, course, comment);
     }

--- a/src/main/java/edu/sfsu/AdvisingServlet.java
+++ b/src/main/java/edu/sfsu/AdvisingServlet.java
@@ -205,7 +205,7 @@ public class AdvisingServlet extends HttpServlet {
                 //System.out.println(student.id);
                 List<Course> course_list = campusDB.getStudent(student.id).courses;
                 for (Course course : course_list) {
-                    System.out.println(course.courseName + " " + course.semester);
+                    //System.out.println(course.courseName + " " + course.semester);
                     if (course.courseName.equals("CSC 413") && course.semester.equals(Util.formatSemester(current_semester))) {
                         csc413_students.add(student);
                         break;

--- a/src/main/java/edu/sfsu/AdvisingServlet.java
+++ b/src/main/java/edu/sfsu/AdvisingServlet.java
@@ -185,7 +185,7 @@ public class AdvisingServlet extends HttpServlet {
 
     private void processGenerateList(PrintWriter out, String type) {
         List<Student> students = checkpointDB.generateList(type);
-        System.out.println(type);
+        //System.out.println(type);
         if (type.equals("413_current")){
             students = generate413Student(students); //TODO create method matching this in each campusTestDB and oracle DB.
         }
@@ -196,18 +196,23 @@ public class AdvisingServlet extends HttpServlet {
     private List<Student> generate413Student(List<Student> students){
         List<Student> csc413_students = new ArrayList<Student>();
         String current_semester = Util.getCurrentSemester();
-        System.out.println(Util.formatSemester(current_semester));
+        //System.out.println(Util.formatSemester(current_semester));
 
-        for (Student student : students ){
-            System.out.println(student.id);
-            List<Course> course_list = campusDB.getStudent(student.id).courses;
-            for (Course course : course_list){
-                System.out.println(course.courseName + " "+ course.semester);
-                if (course.courseName.equals("CSC 413") && course.semester.equals(Util.formatSemester(current_semester))) {
-                    csc413_students.add(student);
-                    break;
+        int i = 0;
+        while( i < 500) {
+            csc413_students.clear();
+            for (Student student : students) {
+                //System.out.println(student.id);
+                List<Course> course_list = campusDB.getStudent(student.id).courses;
+                for (Course course : course_list) {
+                    System.out.println(course.courseName + " " + course.semester);
+                    if (course.courseName.equals("CSC 413") && course.semester.equals(Util.formatSemester(current_semester))) {
+                        csc413_students.add(student);
+                        break;
+                    }
                 }
             }
+            i++;
         }
         return csc413_students;
 

--- a/src/main/java/edu/sfsu/AdvisingServlet.java
+++ b/src/main/java/edu/sfsu/AdvisingServlet.java
@@ -198,22 +198,18 @@ public class AdvisingServlet extends HttpServlet {
         String current_semester = Util.getCurrentSemester();
         //System.out.println(Util.formatSemester(current_semester));
 
-        int i = 0;
-        while( i < 500) {
-            csc413_students.clear();
-            for (Student student : students) {
-                //System.out.println(student.id);
-                List<Course> course_list = campusDB.getStudent(student.id).courses;
-                for (Course course : course_list) {
-                    //System.out.println(course.courseName + " " + course.semester);
-                    if (course.courseName.equals("CSC 413") && course.semester.equals(Util.formatSemester(current_semester))) {
-                        csc413_students.add(student);
-                        break;
-                    }
+        for (Student student : students) {
+            //System.out.println(student.id);
+            List<Course> course_list = campusDB.getStudent(student.id).courses;
+            for (Course course : course_list) {
+                //System.out.println(course.courseName + " " + course.semester);
+                if (course.courseName.equals("CSC 413") && course.semester.equals(Util.formatSemester(current_semester))) {
+                    csc413_students.add(student);
+                    break;
                 }
             }
-            i++;
         }
+
         return csc413_students;
 
     }

--- a/src/main/java/edu/sfsu/HtmlFormatter.java
+++ b/src/main/java/edu/sfsu/HtmlFormatter.java
@@ -25,10 +25,13 @@ public class HtmlFormatter {
 
 
     private static HTMLSniplet studentInfoFragment;
+    private static HTMLSniplet studentROFragment;
 
     public static void init(ServletContext context) {
         InputStream is = context.getResourceAsStream("/WEB-INF/classes/student_sniplet.html");
         studentInfoFragment = HTMLSniplet.fromInputStream(is);
+        InputStream is_ro = context.getResourceAsStream("/WEB-INF/classes/readonly_student_sniplet.html");
+        studentROFragment = HTMLSniplet.fromInputStream(is_ro);
     }
 
     private static void generateCheckpoint(HTMLSniplet fragment, String studentId, String date, String checkpointDescr,
@@ -37,7 +40,7 @@ public class HtmlFormatter {
         checkpoint.p("checkpoint_id", checkpointId);
         checkpoint.p("student_id", studentId);
         checkpoint.p("checkpoint_descr", checkpointDescr);
-        checkpoint.p("style", showDateField ? "" : " style='display: none;'");
+        //checkpoint.p("style", showDateField ? "" : " style='display: none;'");
         checkpoint.p("checked", (date != null && !"".equals(date)) ? " checked" : "");
         checkpoint.p("date_value", (date != null && !"".equals(date)) ? String.format(" value='%s'", e(date)) : "");
         checkpoint.p("label", showDateField ? "Date" : "Comment");
@@ -103,6 +106,32 @@ public class HtmlFormatter {
 
     public static String generateHtml(Student student) {
         HTMLSniplet fragment = studentInfoFragment.copy();
+        fragment.p("student_first_name", student.firstName);
+        fragment.p("student_last_name", student.lastName);
+        fragment.p("student_email", student.email);
+        fragment.p("student_id", student.id);
+
+        fragment.p("comments", student.comment);
+
+        generateCheckpoint(fragment, student.id, student.checkpointOralPresentation,
+                "Senior Oral Presentation", "oral_presentation", false);
+        generateCheckpoint(fragment, student.id, student.checkpointAdvising413, "413 Advising",
+                "advising_413", true);
+        generateCheckpoint(fragment, student.id, student.checkpointSubmittedApplication,
+                "Submitted Graduate Application", "submitted_appl", true);
+
+        generateClassList(fragment, student, "Core", CourseRequirements.core, true, true);
+        generateClassList(fragment, student, "Electives", CourseRequirements.electives, false, true);
+        generateClassList(fragment, student, "Transfers", transfers, true, false);
+        return fragment.render().toString();
+    }
+    public static String generateHtml(Student student, boolean readonly) {
+        HTMLSniplet fragment = null;
+        if (readonly)
+            fragment = studentROFragment.copy();
+        else
+            fragment = studentInfoFragment.copy();
+
         fragment.p("student_first_name", student.firstName);
         fragment.p("student_last_name", student.lastName);
         fragment.p("student_email", student.email);

--- a/src/main/java/edu/sfsu/db/CampusTestDB.java
+++ b/src/main/java/edu/sfsu/db/CampusTestDB.java
@@ -1,13 +1,28 @@
 package edu.sfsu.db;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 
 public class CampusTestDB extends DB implements CampusDB {
 
+    final static protected String DB_NAME = "ADVISING";
+    final static protected String KEY_STUDENT_ID = "STUDENT_ID";
+
+
+
     public CampusTestDB(String driver, String url, String user, String passwd) {
+        super(driver, url, user, passwd);
+
     }
 
-    public Student getStudent(String id) {
+   /* public Student getStudent(String id) {
         if (!id.equals("123456789")) {
             return null;
         }
@@ -17,14 +32,106 @@ public class CampusTestDB extends DB implements CampusDB {
         student.lastName = "Doe";
         student.email = "john@doe.com";
         Course course = new Course();
-        course.courseName = "CSC 415";
+        course.courseName = "CSC415";
         course.grade = "A-";
         course.semester = "Spring 2018";
         student.courses.add(course);
         return student;
+    }*/
+
+    public Student getStudent(String id) {
+        Connection connection = null;
+        Student student = null;
+
+        try {
+            connection = getConnection();
+            connection.setCatalog(DB_NAME);
+            String query = "select STUDENT_FIRST_NAME, STUDENT_LAST_NAME, STUDENT_EMAIL from student_list_tester where " + KEY_STUDENT_ID + " = ?";
+            PreparedStatement ps = connection.prepareStatement(query);
+            ps.setString(1, id);
+            ResultSet rs = ps.executeQuery();
+
+            if (rs.next()) {
+                student = new Student(id);
+                student.firstName = rs.getString("STUDENT_FIRST_NAME");
+                student.lastName = rs.getString("STUDENT_LAST_NAME");
+                student.email = rs.getString("STUDENT_EMAIL");
+
+
+                query = "select GRADE, CLASS_NAME, SEMESTER_TAKEN from class_list_tester where " + KEY_STUDENT_ID + " = ?";
+                ps = connection.prepareStatement(query);
+                ps.setString(1, id);
+                ResultSet rs_g = ps.executeQuery();
+
+                while (rs_g.next()) {
+                    Course course = new Course();
+                    String course_name = rs_g.getString("CLASS_NAME");
+                    Matcher matcher = Pattern.compile("\\d+").matcher(course_name);
+                    matcher.find();
+                    String numerical = matcher.group();
+                    String[] parts = course_name.split(numerical);
+                    course.courseName = parts[0] + " " + numerical;
+                    course.grade = scoreToGrade(rs_g.getDouble("GRADE"));
+                    course.semester = rs_g.getString("SEMESTER_TAKEN");
+                    student.courses.add(course);
+
+                }
+                rs_g.close();
+                rs.close();
+
+
+                connection.close();
+                System.out.println("Done");
+                System.out.println(student.lastName);
+                return student;
+
+            }
+
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException e) {
+                }
+            }
+
+        }
+
+        return student;
+    }
+
+    private String scoreToGrade(double score){
+        if (score > 92)
+        return "A";
+        else if  (score > 89)
+        return "A-";
+        else if  (score > 86)
+        return "B+";
+        else if  (score > 82)
+        return "B";
+        else if  (score > 79)
+        return "B-";
+        else if  (score > 76)
+        return "C+";
+        else if  (score > 72)
+        return "C";
+        else if  (score > 69)
+        return "C-";
+        else if  (score > 66)
+        return "D+";
+        else if  (score > 62)
+        return "D";
+        else if  (score > 60)
+        return "D-";
+        else
+        return "F";
     }
 
     public void getStudentInfo(List<Student> students) {
     }
+
 
 }

--- a/src/main/java/edu/sfsu/db/CheckpointDB.java
+++ b/src/main/java/edu/sfsu/db/CheckpointDB.java
@@ -155,6 +155,9 @@ public class CheckpointDB extends DB {
             if (type.equals("graduated")) {
                 query += " where " + KEY_SUBMITTED_APPL + " <> ''";
             }
+            if (type.equals("413_current")) {
+                query += " where " + KEY_SUBMITTED_APPL + " = '' or "+KEY_SUBMITTED_APPL + " is null";
+            }
             PreparedStatement ps = connection.prepareStatement(query);
             ResultSet rs = ps.executeQuery();
 
@@ -167,6 +170,7 @@ public class CheckpointDB extends DB {
                 student.checkpointAdvising413 = rs.getString(KEY_ADVISING_413);
                 student.checkpointSubmittedApplication = rs.getString(KEY_SUBMITTED_APPL);
                 list.add(student);
+                //System.out.println(student.firstName);
             }
             rs.close();
             ps.close();

--- a/src/main/resources/readonly_student_sniplet.html
+++ b/src/main/resources/readonly_student_sniplet.html
@@ -1,0 +1,80 @@
+<h4>%%student_first_name%% %%student_last_name%% (%%student_id%%) &lt;<a href='mailto:%%student_email%%'>%%student_email%%</a>&gt;</h4>
+<div class='general'>
+    <input type='hidden' id='student_first_name' value='%%student_first_name%%'>
+    <input type='hidden' id='student_last_name' value='%%student_last_name%%'>
+    <input type='hidden' id='student_email' value='%%student_email%%'>
+    <h5>Comments</h5>
+        <textarea disabled id='comments' placeholder='No comments' style='width: 100%' rows='12'>%%comments%%</textarea>
+
+    <div class='vertical-padding'></div>
+    <h5>Checkpoints</h5>
+    <table class='mdl-data-table mdl-js-data-table mdl-shadow--2dp'>
+        <thead>
+            <tr>
+                <th class='mdl-data-table__cell--non-numeric'></th>
+                <th class='mdl-data-table__cell--non-numeric'>Checkpoint</th>
+                <th class='mdl-data-table__cell--non-numeric'>Date/Comment</th>
+            </tr>
+        </thead>
+        <tbody>
+        <!--%%BLOCK:checkpoint%%-->
+        <tr>
+            <td class='mdl-data-table__cell--non-numeric'>
+                <label id='label_%%checkpoint_id%%' class='mdl-switch mdl-js-switch mdl-js-ripple-effect' for='%%checkpoint_id%%' %%style%%>
+                    <input type='checkbox' id='%%checkpoint_id%%' class='mdl-switch__input' disabled %%checked%%/>
+                    <span class='mdl-switch__label'></span>
+                </label>
+            </td>
+            <td class='mdl-data-table__cell--non-numeric'>%%checkpoint_descr%%</td>
+            <td class='mdl-data-table__cell--non-numeric'>
+                <form onsubmit="return update_checkpoints('%%student_id%%');">
+                    <div class='mdl-textfield mdl-js-textfield'>
+                        <input class='mdl-textfield__input' type='text' size='10' id='date_%%checkpoint_id%%' disabled %%date_value%%/>
+                        <label class='mdl-textfield__label' for='date_%%checkpoint_id%%' >%%label%%...</label>
+                    </div>
+                </form>
+            </td>
+        </tr>
+        <!--%%END%%-->
+        </tbody>
+    </table>
+</div>
+
+<!--%%BLOCK:section%%-->
+<div class='vertical-padding'></div>
+<h5>%%heading%%</h5>
+  <table class='mdl-data-table mdl-js-data-table mdl-shadow--2dp full-width'>
+    <thead>
+      <tr>
+        <th class='mdl-data-table__cell--non-numeric'>Course</th>
+        <!--%%BLOCK:details%%-->
+        <th class='mdl-data-table__cell--non-numeric'>Transfer</th>
+        <th class='mdl-data-table__cell--non-numeric'>Semester</th>
+        <th class='mdl-data-table__cell--non-numeric'>Grade</th>
+        <!--%%END%%-->
+        <th class='mdl-data-table__cell--non-numeric full-width'>Comment</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!--%%BLOCK:course%%-->
+      <tr>
+        <td class='mdl-data-table__cell--non-numeric'>%%course_name%%</td>
+        <!--%%BLOCK:details%%-->
+        <td class='mdl-data-table__cell--non-numeric'>%%transfer%%</td>
+        <td class='mdl-data-table__cell--non-numeric'>%%semester%%</td>
+        <td class='mdl-data-table__cell--non-numeric'>%%grade%%</td>
+        <!--%%END%%-->
+        <!--%%BLOCK:comment%%-->
+        <td class='mdl-data-table__cell--non-numeric'>
+            <div class='mdl-textfield mdl-js-textfield full-width'>
+              <input class='mdl-textfield__input full-width' type='text' id='%%course_id%%' %%comment%% disabled/>
+              <label class='mdl-textfield__label' for='%%course_id%%' disabled>Comment...</label>
+            </div>
+        </td>
+        <!--%%END%%-->
+      </tr>
+      <!--%%END%%-->
+    </tbody>
+  </table>
+<!--%%END%%-->
+  

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -73,6 +73,13 @@
             });
             return false;
         }
+        function student_login() {
+
+                var section_main_read_only = document.getElementById("senior_advising_read_only");
+                section_main_read_only.style.display = "block";
+                section_login.style.display = "none";
+            return false;
+        }
 
         function show_print_page() {
             var printWindow = window.open("", "", "width=800, height=800");
@@ -82,19 +89,27 @@
             printWindow.document.close();
         }
 
-        function lookup_student() {
+        function lookup_student(readonly) {
             $('#student_id').blur();
             var id = document.getElementById("student_id");
             var section = document.getElementById("section_student_info");
             var info = document.getElementById("student_info");
+            if (readonly =="true"){
+                id = document.getElementById("student_id_ro");
+                section = document.getElementById("section_student_info_ro");
+                info = document.getElementById("student_info_ro");
+            }
+
             section.style.display = "none";
             show_spinner();
-            $.post("lookup-student", {token: token, id: id.value}, function(data, status) {
+            $.post("lookup-student", {token: token, id: id.value, readonly: readonly}, function(data, status) {
+                console.log(token);
                 info.innerHTML = data;
                 componentHandler.upgradeAllRegistered();
                 section.style.display = "block";
                 hide_spinner();
             });
+            console.log(id.value)
             return false;
         }
 
@@ -233,6 +248,9 @@
                             <span class="mdl-textfield__error">Wrong password!</span>
                         </div>
                     </form>
+<!--
+                    <button onclick="return student_login();">Student Access</button>
+-->
                 </div>
             </section>
         </div>
@@ -247,7 +265,7 @@
             <section class="section--center mdl-grid mdl-grid--no-spacing">
                 <div class="mdl-card__supporting-text">
                     <h4>Senior Advising</h4>
-                    <form onsubmit="return lookup_student();">
+                    <form onsubmit="return lookup_student('false');">
                         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
                             <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="student_id" />
                             <label class="mdl-textfield__label" for="student_id">Student ID</label>
@@ -261,6 +279,7 @@
                 </div>
             </section>
         </div>
+        \
         <div class="mdl-layout__tab-panel" id="advising413">
             <section class="section--center mdl-grid mdl-grid--no-spacing">
                 <div class="mdl-card__supporting-text">
@@ -268,6 +287,11 @@
                     <p>Compile a list of all students who have received 413 advising. A future version will
                       allow to specify a date range.</p>
                     <button class="mdl-button mdl-js-button mdl-button--fab" onclick="return generateList(this, '413')">
+                        <i class="material-icons">forward</i>
+                    </button>
+                    <p>Compile a list of all students who are currently enrolled in 413 advising in the current semester. </p>
+
+                    <button class="mdl-button mdl-js-button mdl-button--fab" onclick="return generateList(this, '413_current')">
                         <i class="material-icons">forward</i>
                     </button>
                 </div>
@@ -286,6 +310,24 @@
             </section>
         </div>
     </main>
+    <div class="mdl-layout__tab-panel" id="senior_advising_read_only" style="display: none">
+        <section class="section--center mdl-grid mdl-grid--no-spacing">
+            <div class="mdl-card__supporting-text">
+                <h4>Senior Advising</h4>
+                <form onsubmit="return lookup_student('true');">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="student_id_ro" />
+                        <label class="mdl-textfield__label" for="student_id">Student ID</label>
+                        <span class="mdl-textfield__error">Input is not a student ID!</span>
+                    </div>
+                </form>
+            </div>
+            <div id="section_student_info_ro" style="display: none">
+                <img style="float: right" onclick="show_print_page()" src="ic_print_black_24dp_1x.png"/>
+                <div id="student_info_ro"></div>
+            </div>
+        </section>
+    </div>
     <div id="toast" class="mdl-js-snackbar mdl-snackbar">
         <div class="mdl-snackbar__text"></div>
         <button class="mdl-snackbar__action" type="button"></button>


### PR DESCRIPTION
Hi Dr. Puder, 

I have added the feature of creating a query that pulls only the students the students currently enrolled into CSC 413. Also included is the readonly version of the student view, which is unnecessary at this point so I just commented out the button that would let you access it. Changes to CampustTestDB were also made to allow it to work with my testing server.  

Of the above changes, only the CSC 413 related item is actually necessary for the project. In order to run properly, it assumes that all student IDs are stored in the checkpoint DB, and then queries the campus DB for their course history. If this is not the case I can rewrite it to match. 

My next steps will be to repeat this query for the graduate application, and then I can add the time specific queries to each as well. 

 Let me know if you have any questions. Future pull requests will be focused on a single issue. 

 -Tom 